### PR TITLE
Review feedback

### DIFF
--- a/docs/ipam.md
+++ b/docs/ipam.md
@@ -130,6 +130,13 @@ In more detail:
      owned by the peer requesting the space, and one at the end of the
      hole owned by the requestee.
   4. It has no space.
+- Tombstones are designed to expire after 2 weeks.  Host clocks need
+  to be reasonably within sync; if the host clocks differ by more than
+  2 weeks, peer deletion will behave inconsistently. Similarly, you
+  should not allow network partitions to persist for longer than 2 weeks,
+  as you may see previously deleted hosts reappearing.  Nodes gossip
+  their current time, and if a receiving host detects more than 1 hour
+  of clock skew, the gossip will be rejected and the connection dropped.
 
 ## Initialisation
 

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -246,9 +246,6 @@ func TestTombstoneEveryone(t *testing.T) {
 	addr := alloc2.Allocate("foo", nil)
 	wt.AssertTrue(t, addr != nil, "Failed to get address")
 
-	addr = alloc1.Allocate("foo2", nil)
-	wt.AssertTrue(t, addr != nil, "Failed to get address")
-
 	addr = alloc3.Allocate("bar", nil)
 	wt.AssertTrue(t, addr != nil, "Failed to get address")
 
@@ -261,7 +258,7 @@ func TestTombstoneEveryone(t *testing.T) {
 	wt.AssertSuccess(t, alloc1.TombstonePeer(alloc2.ourName.String()))
 	wt.AssertSuccess(t, alloc1.TombstonePeer(alloc3.ourName.String()))
 
-	wt.AssertTrue(t, alloc1.ring.Empty(), "Ring not empy!")
+	wt.AssertTrue(t, alloc1.ring.Empty(), "Ring not empty!")
 
 	addr = alloc1.Allocate("foo", nil)
 	wt.AssertTrue(t, addr != nil, "Failed to get address")

--- a/ipam/ring/ring.go
+++ b/ipam/ring/ring.go
@@ -460,6 +460,10 @@ func (r *Ring) String() string {
 // how many free ips are in a given range, so that ChoosePeerToAskForSpace
 // can make more intelligent decisions.
 func (r *Ring) ReportFree(startIP net.IP, free uint32) {
+	r.assertInvariants()
+	defer r.assertInvariants()
+	defer r.updateExportedVariables()
+
 	start := utils.IP4int(startIP)
 	entries := r.Entries.filteredEntries() // We don't want to report free on tombstones
 

--- a/ipam/ring/ring_test.go
+++ b/ipam/ring/ring_test.go
@@ -348,7 +348,7 @@ func TestFindFree(t *testing.T) {
 	wt.AssertTrue(t, err == ErrNoFreeSpace, "Expected ErrNoFreeSpace")
 
 	// We shouldn't return outselves
-	ring1.ReportFree(ipStart, 10)
+	ring1.ReportFree(map[uint32]uint32{start: 10})
 	_, err = ring1.ChoosePeerToAskForSpace()
 	wt.AssertTrue(t, err == ErrNoFreeSpace, "Expected ErrNoFreeSpace")
 
@@ -368,6 +368,22 @@ func TestFindFree(t *testing.T) {
 	peer, err = ring1.ChoosePeerToAskForSpace()
 	wt.AssertSuccess(t, err)
 	wt.AssertEquals(t, peer, peer2name)
+}
+
+func TestReportFree(t *testing.T) {
+	ring1 := New(ipStart, ipEnd, peer1name)
+	ring2 := New(ipStart, ipEnd, peer2name)
+
+	ring1.ClaimItAll()
+	ring1.GrantRangeToHost(ipMiddle, ipEnd, peer2name)
+	ring1.TombstonePeer(peer1name, 10)
+	wt.AssertSuccess(t, ring2.merge(*ring1))
+
+	freespace := make(map[uint32]uint32)
+	for _, r := range ring2.OwnedRanges() {
+		freespace[utils.IP4int(r.Start)] = 0
+	}
+	ring2.ReportFree(freespace)
 }
 
 func TestMisc(t *testing.T) {


### PR DESCRIPTION
- Gossip current time; fail to merge gossips when clock skew is detected.
- Add test for panicing bug David found
- Have Ring.ReportFree handle the case of reporting freespace at the origin when there is no token there, due to the range being split by OwnedRanges()
