### PR TITLE
Review feedback

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -107,7 +107,7 @@ func (alloc *Allocator) Start() {
 	go alloc.actorLoop(actionChan)
 }
 
-// Make the actor routine exit, for test purposes ONLY because any
+// Stop makes the actor routine exit, for test purposes ONLY because any
 // calls after this is processed will hang. Async.
 func (alloc *Allocator) Stop() {
 	alloc.actionChan <- nil
@@ -206,13 +206,13 @@ func hasBeenCancelled(cancelChan <-chan bool) func() bool {
 
 // Allocate (Sync) - get IP address for container with given name
 // if there isn't any space we block indefinitely
-func (alloc *Allocator) Allocate(ident string, cancelChan <-chan bool) (bool, utils.Address) {
+func (alloc *Allocator) Allocate(ident string, cancelChan <-chan bool) (utils.Address, error) {
 	resultChan := make(chan allocateResult)
 	op := &allocate{resultChan: resultChan, ident: ident,
 		hasBeenCancelled: hasBeenCancelled(cancelChan)}
 	alloc.doOperation(op, &alloc.pendingAllocates)
 	result := <-resultChan
-	return result.ok, result.addr
+	return result.addr, result.err
 }
 
 // Claim an address that we think we should own (Sync)

--- a/ipam/getfor.go
+++ b/ipam/getfor.go
@@ -6,8 +6,8 @@ import (
 )
 
 type allocateResult struct {
-	ok   bool
 	addr utils.Address
+	err  error
 }
 
 type allocate struct {
@@ -25,14 +25,14 @@ func (g *allocate) Try(alloc *Allocator) bool {
 
 	// If we have previously stored an address for this container, return it.
 	if addr, found := alloc.owned[g.ident]; found {
-		g.resultChan <- allocateResult{true, addr}
+		g.resultChan <- allocateResult{addr, nil}
 		return true
 	}
 
 	if ok, addr := alloc.space.Allocate(); ok {
 		alloc.debugln("Allocated", addr, "for", g.ident)
 		alloc.addOwned(g.ident, addr)
-		g.resultChan <- allocateResult{true, addr}
+		g.resultChan <- allocateResult{addr, nil}
 		return true
 	}
 
@@ -46,7 +46,7 @@ func (g *allocate) Try(alloc *Allocator) bool {
 }
 
 func (g *allocate) Cancel() {
-	g.resultChan <- allocateResult{false, 0}
+	g.resultChan <- allocateResult{0, fmt.Errorf("Request Cancelled")}
 }
 
 func (g *allocate) String() string {

--- a/ipam/http.go
+++ b/ipam/http.go
@@ -1,116 +1,76 @@
 package ipam
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
-	"strings"
+
+	"github.com/gorilla/mux"
 
 	"github.com/weaveworks/weave/common"
 	"github.com/weaveworks/weave/ipam/utils"
 )
-
-/*
-The operations supported by this interface are:
-
-  * POST /ip/<containerid> - return a CIDR-format address for the
-    container with ID <containerid>.  This ID should be the full
-    long-format hex number ID that Docker has given it.  If you call
-    this multiple times for the same container it will always return
-    the same address. The return value is in CIDR format (preparatory
-    for future extension to support multiple subnets). Does not return
-    until an address is available (or the allocator shuts down)
-  * PUT /ip/<containerid>/<ip> - state that address <ip> is associated
-    with <containerid>.  If you send an address outside of the space
-    managed by IPAM then this request is ignored.
-  * DELETE /ip/<containerid> - free all ip addresses associated with
-    <containerid>
-
-*/
-
-// Parse a URL of the form /xxx/<identifier>
-func parseURL(url string) (identifier string, err error) {
-	parts := strings.Split(url, "/")
-	if len(parts) != 3 {
-		return "", errors.New("Unable to parse url: " + url)
-	}
-	return parts[2], nil
-}
-
-// Parse a URL of the form /xxx/<identifier>/<ip-address>
-func parseURLWithIP(url string) (identifier string, ipaddr string, err error) {
-	parts := strings.Split(url, "/")
-	if len(parts) != 4 {
-		return "", "", errors.New("Unable to parse url: " + url)
-	}
-	return parts[2], parts[3], nil
-}
 
 func badRequest(w http.ResponseWriter, err error) {
 	http.Error(w, err.Error(), http.StatusBadRequest)
 	common.Warning.Println(err.Error())
 }
 
-func invalidIP(w http.ResponseWriter, ip string) {
-	badRequest(w, fmt.Errorf("Invalid IP in request: %s", ip))
-}
-
 // HandleHTTP wires up ipams HTTP endpoints to the provided mux.
-func (alloc *Allocator) HandleHTTP(mux *http.ServeMux) {
-	mux.HandleFunc("/ip/", func(w http.ResponseWriter, r *http.Request) {
-		var closedChan = w.(http.CloseNotifier).CloseNotify()
-
-		switch r.Method {
-		case "PUT": // caller supplies an address to reserve for a container
-			ident, ipStr, err := parseURLWithIP(r.URL.Path)
-			if err != nil {
-				badRequest(w, err)
-			} else if ip := net.ParseIP(ipStr); ip == nil {
-				invalidIP(w, ipStr)
-			} else if err = alloc.Claim(ident, utils.IP4Address(ip), closedChan); err != nil {
-				badRequest(w, fmt.Errorf("Unable to claim IP address %s: %s", ip, err))
-			}
-		case "POST": // caller requests one address for a container
-			ident, err := parseURL(r.URL.Path)
-			if err != nil {
-				badRequest(w, err)
-			} else if ok, newAddr := alloc.Allocate(ident, closedChan); ok {
-				fmt.Fprintf(w, "%s/%d", newAddr.String(), alloc.prefixLen)
-			} else {
-				badRequest(w, fmt.Errorf("Allocator shutting down"))
-			}
-		case "DELETE": // one container has gone away
-			ident, err := parseURL(r.URL.Path)
-			if err != nil {
-				badRequest(w, err)
-			} else if err = alloc.Free(ident); err != nil {
-				badRequest(w, err)
-			}
-		default:
-			http.Error(w, "Verb not handled", http.StatusBadRequest)
+func (alloc *Allocator) HandleHTTP(router *mux.Router) {
+	router.Methods("PUT").Path("/ip/{id}/{ip}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		closedChan := w.(http.CloseNotifier).CloseNotify()
+		vars := mux.Vars(r)
+		ident := vars["id"]
+		ipStr := vars["ip"]
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			badRequest(w, fmt.Errorf("Invalid IP in request: %s", ipStr))
+			return
 		}
+
+		if err := alloc.Claim(ident, utils.IP4Address(ip), closedChan); err != nil {
+			badRequest(w, fmt.Errorf("Unable to claim IP address %s: %s", ip, err))
+			return
+		}
+
+		w.WriteHeader(204)
 	})
-	mux.HandleFunc("/tombstone-self", func(w http.ResponseWriter, r *http.Request) {
+
+	router.Methods("POST").Path("/ip/{id}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		closedChan := w.(http.CloseNotifier).CloseNotify()
+		ident := mux.Vars(r)["id"]
+		newAddr, err := alloc.Allocate(ident, closedChan)
+		if err != nil {
+			badRequest(w, err)
+			return
+		}
+
+		fmt.Fprintf(w, "%s/%d", newAddr.String(), alloc.prefixLen)
+	})
+
+	router.Methods("DELETE").Path("/ip/{id}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ident := mux.Vars(r)["id"]
+		if err := alloc.Free(ident); err != nil {
+			badRequest(w, err)
+			return
+		}
+
+		w.WriteHeader(204)
+	})
+
+	router.Methods("DELETE").Path("/peer").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		alloc.Shutdown()
+		w.WriteHeader(204)
 	})
-	mux.HandleFunc("/peer/", func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case "DELETE":
-			ident, err := parseURL(r.URL.Path)
-			if err != nil {
-				badRequest(w, err)
-				return
-			}
 
-			if err := alloc.AdminTakeoverRanges(ident); err != nil {
-				badRequest(w, err)
-				return
-			}
-
-			w.WriteHeader(204)
-		default:
-			http.Error(w, "Verb not handled", http.StatusBadRequest)
+	router.Methods("DELETE").Path("/peer/{id}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ident := mux.Vars(r)["id"]
+		if err := alloc.AdminTakeoverRanges(ident); err != nil {
+			badRequest(w, err)
+			return
 		}
+
+		w.WriteHeader(204)
 	})
 }

--- a/weave
+++ b/weave
@@ -931,7 +931,7 @@ case "$COMMAND" in
         ;;
     reset)
         [ $# -eq 0 ] || usage
-        http_call $CONTAINER_NAME $HTTP_PORT POST /tombstone-self >/dev/null 2>&1 || true
+        http_call $CONTAINER_NAME $HTTP_PORT DELETE /peer >/dev/null 2>&1 || true
         docker stop  $CONTAINER_NAME     >/dev/null 2>&1 || true
         docker stop  $DNS_CONTAINER_NAME >/dev/null 2>&1 || true
         docker rm -f $CONTAINER_NAME     >/dev/null 2>&1 || true


### PR DESCRIPTION
- use gorilla mux for ipam http
- make allocator.Allocate return an error
- change the endpoint for shutdown to DELETE /peer instead of POST /tombstone-self
